### PR TITLE
Expand supported VScode version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "R Markdown"
   ],
   "engines": {
-    "vscode": "^1.99.0"
+    "vscode": "^1.96.2"
   },
   "categories": [
     "Programming Languages"


### PR DESCRIPTION
Currently, minimum supported VS Code version is 1.99, but Cursor is currently using VS Code version 1.96.2. Tested PR on macOS with updated version range on Cursor with no issues + ran grammar tests.